### PR TITLE
bug / iconanchor messstelle angepasst

### DIFF
--- a/frontend/src/components/map/ZaehlstelleMap.vue
+++ b/frontend/src/components/map/ZaehlstelleMap.vue
@@ -553,8 +553,9 @@ export default class ZaehlstelleMap extends Vue {
         let defaultIcon = new Icon({
             iconUrl: markerIconDiamondViolet,
             shadowUrl: markerIconDiamondShadow,
-            shadowAnchor: [8, 25],
+            shadowAnchor: [8, 45],
             iconSize: [25, 41],
+            iconAnchor: [12, 41],
         });
 
         if (messstelleKarte.status === MessstelleStatus.IN_PLANUNG) {


### PR DESCRIPTION
**Description**

die messstellen marker icons haben mit den gleichen koordinaten nicht auf die gleiche stelle gezeigt wie die zählstellen
ausrichtung der icons angepasst

**Reference**

Issues #XXX
