### PR TITLE
Remove keycloak.scope placeholder

### DIFF
--- a/.github/workflows/build_push_ghcr.yaml
+++ b/.github/workflows/build_push_ghcr.yaml
@@ -1,0 +1,78 @@
+name: build image and push to ghcr.io
+
+on: 
+  push:
+    branches: [main]
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  compliance:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Advance Security Policy as Code
+        uses: advanced-security/policy-as-code@v2.4.1
+        with:
+          policy: it-at-m/policy-as-code
+          policy-path: default.yaml
+          token: ${{ secrets.GITHUB_TOKEN }}
+          argvs: "--disable-dependabot --disable-secret-scanning --disable-code-scanning --display"
+
+  build-and-push-image:
+    needs: compliance
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      packages: write
+    
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@65b78e6e13532edd9afa3aa52ac7964289d1a9c1
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=raw,value=main-ls1
+          labels: |
+            maintainer=it@m, Landeshauptstadt Muenchen (LHM)
+      
+      - name: Install Java and Maven
+        uses: actions/setup-java@v3
+        with:
+          java-version: 11
+          distribution: "temurin"
+          cache: "maven"
+
+      - name: Set up Node 16
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16
+
+      - name: Build with Maven
+        run: mvn -B verify "-Dspring-boot.run.jvmArguments=-Dfile.encoding=UTF-8" -DskipTests=true
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@f2a1d5e99d037542a71f64918e516c093c6f3fc4
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          

--- a/apigateway/src/main/resources/application.yml
+++ b/apigateway/src/main/resources/application.yml
@@ -60,8 +60,6 @@ spring:
           keycloak:
             client-id: dave
             client-secret: TBD
-            scope:
-              - <Hier Scope definieren>
 
   mvc:
     log-request-details: false


### PR DESCRIPTION
**Description**

Addition to #49: Remove placeholder <Hier Scope definieren> for spring.security.oauth2.client.registration.keycloak.scope. The placeholder value leads to an Error when deploying dave-external via helm chart: 

**Reference**

Issues #XXX
