### PR TITLE
Update Dockerfile base image to Java 21

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,4 @@
-FROM registry.access.redhat.com/ubi8/openjdk-11:latest
+# For documentation see https://jboss-container-images.github.io/openjdk/
+FROM registry.access.redhat.com/ubi9/openjdk-21-runtime:latest
 
 COPY apigateway/target/*.jar /deployments/spring-boot-application.jar


### PR DESCRIPTION
**Description**

OpenJDK base image in Dockerfile updated to Java 21.

**Reference**

DAVE-395
