### PR TITLE
Bug/fv 179 adminportal daveng test verkehrsarten speichern

### DIFF
--- a/frontend/src/components/zaehlung/form/VerkehrsartForm.vue
+++ b/frontend/src/components/zaehlung/form/VerkehrsartForm.vue
@@ -118,6 +118,14 @@ watch(
   }
 );
 
+watch(
+  () => zaehlung.value,
+  () => {
+    resetForm();
+  },
+  { immediate: true, deep: true }
+);
+
 const pkwEinheitenOfStore = computed(() => {
   return pkweinheitStore.getPkwEinheit;
 });

--- a/frontend/src/components/zaehlung/form/ZaehlungForm.vue
+++ b/frontend/src/components/zaehlung/form/ZaehlungForm.vue
@@ -133,8 +133,10 @@ watch(
 
 watch(
   () => zaehlung.value.zaehlart,
-  () => {
-    zaehlung.value.kategorien = [];
+  (newValue, oldValue) => {
+    if (oldValue !== undefined && newValue !== oldValue) {
+      zaehlung.value.kategorien = [];
+    }
   },
   { immediate: true }
 );


### PR DESCRIPTION
# Description

<!-- Add a short description of what the request is all about here -->
Behebt den Fehler, dass im Adminportal keine Verkehrsarten mehr angezeigt werden.

# Issue References

<!-- Add the corresponding issues here -->
FV-179
 
# Definition of Done

<!-- Check all completed DoD requirements here -->

- [x] Acceptance criteria are met
- [x] Testing is done (unit-tests, DEV-environment)
- [x] Build/Test workflow has successfully finished
- [x] Release notes are complemented
- [x] Documentation is complemented (operator manual, system specification, etc.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved form reset behavior to properly respond to data changes
  * Enhanced form field handling to preserve existing data during initialization while correctly clearing fields on subsequent updates

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->