### PR TITLE
FV-236 Fix Bug mit Aus- und Abwahl aller Fahrzeugkategorien bei Zählarten QJS, FJS und QU

### DIFF
--- a/frontend/src/components/zaehlung/form/VerkehrsartForm.vue
+++ b/frontend/src/components/zaehlung/form/VerkehrsartForm.vue
@@ -9,7 +9,7 @@
       <v-row dense>
         <v-col>
           <v-checkbox
-            v-if="allCategoriesAreAllowed"
+            v-if="areAllVehicleCategoriesSelectable"
             v-model="pkw"
             :label="pkwLabel"
             color="quaternary"
@@ -17,7 +17,7 @@
             @update:model-value="updateKategorieWithPkw"
           />
           <v-checkbox
-            v-if="allCategoriesAreAllowed"
+            v-if="areAllVehicleCategoriesSelectable"
             v-model="lkw"
             :label="lkwLabel"
             color="quaternary"
@@ -25,7 +25,7 @@
             @update:model-value="updateKategorieWithLkw"
           />
           <v-checkbox
-            v-if="allCategoriesAreAllowed"
+            v-if="areAllVehicleCategoriesSelectable"
             v-model="lz"
             :label="lzLabel"
             color="quaternary"
@@ -33,7 +33,7 @@
             @update:model-value="updateKategorieWithLz"
           />
           <v-checkbox
-            v-if="allCategoriesAreAllowed"
+            v-if="areAllVehicleCategoriesSelectable"
             v-model="bus"
             :label="busLabel"
             color="quaternary"
@@ -41,7 +41,7 @@
             @update:model-value="updateKategorieWithBus"
           />
           <v-checkbox
-            v-if="allCategoriesAreAllowed"
+            v-if="areAllVehicleCategoriesSelectable"
             v-model="krad"
             :label="kradLabel"
             color="quaternary"
@@ -134,7 +134,7 @@ const labelSelectOrDeselectAll = computed(() => {
   return selectOrDeselectAllVmodel.value ? "Alles abwählen" : "Alles auswählen";
 });
 
-const allCategoriesAreAllowed = computed(() => {
+const areAllVehicleCategoriesSelectable = computed(() => {
   return checkIfZaehlartOfZaehlungAllowsAllCategories();
 });
 
@@ -238,7 +238,7 @@ function updateKategorieWithFuss() {
  */
 function selectOrDeselectAll() {
   // Setzen der Checkboxen
-  if (allCategoriesAreAllowed.value) {
+  if (areAllVehicleCategoriesSelectable.value) {
     pkw.value = selectOrDeselectAllVmodel.value;
     lkw.value = selectOrDeselectAllVmodel.value;
     lz.value = selectOrDeselectAllVmodel.value;
@@ -257,7 +257,7 @@ function selectOrDeselectAll() {
   // Hinzufügen der Kategorien zur Zählung.
   zaehlung.value.kategorien = [];
   if (selectOrDeselectAllVmodel.value) {
-    if (allCategoriesAreAllowed.value) {
+    if (areAllVehicleCategoriesSelectable.value) {
       addKategorieToZaehlung(Fahrzeug.PKW);
       addKategorieToZaehlung(Fahrzeug.LKW);
       addKategorieToZaehlung(Fahrzeug.LZ);

--- a/frontend/src/components/zaehlung/form/VerkehrsartForm.vue
+++ b/frontend/src/components/zaehlung/form/VerkehrsartForm.vue
@@ -239,14 +239,15 @@ function selectOrDeselectAll() {
   zaehlung.value.kategorien = [];
   if (selectOrDeselectAllVmodel.value) {
     if (allCategoriesAreAllowed.value) {
-      zaehlung.value.kategorien.push(Fahrzeug.PKW);
-      zaehlung.value.kategorien.push(Fahrzeug.LKW);
-      zaehlung.value.kategorien.push(Fahrzeug.LZ);
-      zaehlung.value.kategorien.push(Fahrzeug.BUS);
-      zaehlung.value.kategorien.push(Fahrzeug.KRAD);
+      addKategorie(Fahrzeug.PKW);
+      addKategorie(Fahrzeug.PKW);
+      addKategorie(Fahrzeug.LKW);
+      addKategorie(Fahrzeug.LZ);
+      addKategorie(Fahrzeug.BUS);
+      addKategorie(Fahrzeug.KRAD);
     }
-    zaehlung.value.kategorien.push(Fahrzeug.RAD);
-    zaehlung.value.kategorien.push(Fahrzeug.FUSS);
+    addKategorie(Fahrzeug.RAD);
+    addKategorie(Fahrzeug.FUSS);
   }
 }
 

--- a/frontend/src/components/zaehlung/form/VerkehrsartForm.vue
+++ b/frontend/src/components/zaehlung/form/VerkehrsartForm.vue
@@ -9,7 +9,7 @@
       <v-row dense>
         <v-col>
           <v-checkbox
-            v-if="notOnlyRadAndFussIsAllowed"
+            v-if="allCategoriesAreAllowed"
             v-model="pkw"
             :label="pkwLabel"
             color="quaternary"
@@ -17,7 +17,7 @@
             @update:model-value="updateKategorieWithPkw"
           />
           <v-checkbox
-            v-if="notOnlyRadAndFussIsAllowed"
+            v-if="allCategoriesAreAllowed"
             v-model="lkw"
             :label="lkwLabel"
             color="quaternary"
@@ -25,7 +25,7 @@
             @update:model-value="updateKategorieWithLkw"
           />
           <v-checkbox
-            v-if="notOnlyRadAndFussIsAllowed"
+            v-if="allCategoriesAreAllowed"
             v-model="lz"
             :label="lzLabel"
             color="quaternary"
@@ -33,7 +33,7 @@
             @update:model-value="updateKategorieWithLz"
           />
           <v-checkbox
-            v-if="notOnlyRadAndFussIsAllowed"
+            v-if="allCategoriesAreAllowed"
             v-model="bus"
             :label="busLabel"
             color="quaternary"
@@ -41,7 +41,7 @@
             @update:model-value="updateKategorieWithBus"
           />
           <v-checkbox
-            v-if="notOnlyRadAndFussIsAllowed"
+            v-if="allCategoriesAreAllowed"
             v-model="krad"
             :label="kradLabel"
             color="quaternary"
@@ -134,7 +134,7 @@ const labelSelectOrDeselectAll = computed(() => {
   return selectOrDeselectAllVmodel.value ? "Alles abwählen" : "Alles auswählen";
 });
 
-const notOnlyRadAndFussIsAllowed = computed(() => {
+const allCategoriesAreAllowed = computed(() => {
   const zaehlarten = [Zaehlart.QJS, Zaehlart.QU, Zaehlart.FJS];
   return !zaehlarten.includes(zaehlung.value.zaehlart);
 });
@@ -236,9 +236,9 @@ function selectOrDeselectAll() {
   krad.value = selectOrDeselectAllVmodel.value;
   rad.value = selectOrDeselectAllVmodel.value;
   fuss.value = selectOrDeselectAllVmodel.value;
+  zaehlung.value.kategorien = [];
   if (selectOrDeselectAllVmodel.value) {
-    zaehlung.value.kategorien = [];
-    if (notOnlyRadAndFussIsAllowed.value) {
+    if (allCategoriesAreAllowed.value) {
       zaehlung.value.kategorien.push(Fahrzeug.PKW);
       zaehlung.value.kategorien.push(Fahrzeug.LKW);
       zaehlung.value.kategorien.push(Fahrzeug.LZ);
@@ -247,8 +247,6 @@ function selectOrDeselectAll() {
     }
     zaehlung.value.kategorien.push(Fahrzeug.RAD);
     zaehlung.value.kategorien.push(Fahrzeug.FUSS);
-  } else {
-    zaehlung.value.kategorien = [];
   }
 }
 

--- a/frontend/src/components/zaehlung/form/VerkehrsartForm.vue
+++ b/frontend/src/components/zaehlung/form/VerkehrsartForm.vue
@@ -135,41 +135,49 @@ const labelSelectOrDeselectAll = computed(() => {
 });
 
 const allCategoriesAreAllowed = computed(() => {
-  const zaehlarten = [Zaehlart.QJS, Zaehlart.QU, Zaehlart.FJS];
-  return !zaehlarten.includes(zaehlung.value.zaehlart);
+  return checkIfZaehlartOfZaehlungAllowsAllCategories();
 });
 
+function checkIfZaehlartOfZaehlungAllowsAllCategories() {
+  const zaehlartenWithRestrictedCategories = [
+    Zaehlart.QJS,
+    Zaehlart.QU,
+    Zaehlart.FJS,
+  ];
+  return !zaehlartenWithRestrictedCategories.includes(zaehlung.value.zaehlart);
+}
+
 const pkwLabel = computed(() => {
-  return `Personenkraftwagen (Pkw) ${pkwEinheitenOfStore.value.pkw ? `- PKW-Einheit-Faktor: ${pkwEinheitenOfStore.value.pkw}` : ''}`;
+  return `Personenkraftwagen (Pkw) ${pkwEinheitenOfStore.value.pkw ? `- PKW-Einheit-Faktor: ${pkwEinheitenOfStore.value.pkw}` : ""}`;
 });
 
 const lkwLabel = computed(() => {
-  return `Lastkraftwagen (Lkw) ${pkwEinheitenOfStore.value.lkw ? `- PKW-Einheit-Faktor: ${pkwEinheitenOfStore.value.lkw}` : ''}`;
+  return `Lastkraftwagen (Lkw) ${pkwEinheitenOfStore.value.lkw ? `- PKW-Einheit-Faktor: ${pkwEinheitenOfStore.value.lkw}` : ""}`;
 });
 
 const lzLabel = computed(() => {
-  return `Lastzüge (Lz) ${pkwEinheitenOfStore.value.lastzuege ? `- PKW-Einheit-Faktor: ${pkwEinheitenOfStore.value.lastzuege}` : ''}`;
+  return `Lastzüge (Lz) ${pkwEinheitenOfStore.value.lastzuege ? `- PKW-Einheit-Faktor: ${pkwEinheitenOfStore.value.lastzuege}` : ""}`;
 });
 
 const busLabel = computed(() => {
-  return `Bus ${pkwEinheitenOfStore.value.busse ? `- PKW-Einheit-Faktor: ${pkwEinheitenOfStore.value.busse}` : ''}`;
+  return `Bus ${pkwEinheitenOfStore.value.busse ? `- PKW-Einheit-Faktor: ${pkwEinheitenOfStore.value.busse}` : ""}`;
 });
 
 const kradLabel = computed(() => {
-  return `Krafträder (Krad) ${pkwEinheitenOfStore.value.kraftraeder ? `- PKW-Einheit-Faktor: ${pkwEinheitenOfStore.value.kraftraeder}` : ''}`;
+  return `Krafträder (Krad) ${pkwEinheitenOfStore.value.kraftraeder ? `- PKW-Einheit-Faktor: ${pkwEinheitenOfStore.value.kraftraeder}` : ""}`;
 });
 
 const radLabel = computed(() => {
-  return `Radverkehr ${pkwEinheitenOfStore.value.fahrradfahrer ? `- PKW-Einheit-Faktor: ${pkwEinheitenOfStore.value.fahrradfahrer}` : ''}`;
+  return `Radverkehr ${pkwEinheitenOfStore.value.fahrradfahrer ? `- PKW-Einheit-Faktor: ${pkwEinheitenOfStore.value.fahrradfahrer}` : ""}`;
 });
 
 const fussLabel = computed(() => {
-  return `Fußverkehr ${pkwEinheitenOfStore.value.fussgaenger ? `- PKW-Einheit-Faktor: ${pkwEinheitenOfStore.value.fussgaenger}` : ''}`;
+  return `Fußverkehr ${pkwEinheitenOfStore.value.fussgaenger ? `- PKW-Einheit-Faktor: ${pkwEinheitenOfStore.value.fussgaenger}` : ""}`;
 });
 
 function updateKategorieWithPkw() {
   if (pkw.value) {
-    addKategorie(Fahrzeug.PKW);
+    addKategorieToZaehlung(Fahrzeug.PKW);
   } else {
     removeKategorie(Fahrzeug.PKW);
   }
@@ -177,7 +185,7 @@ function updateKategorieWithPkw() {
 
 function updateKategorieWithLkw() {
   if (lkw.value) {
-    addKategorie(Fahrzeug.LKW);
+    addKategorieToZaehlung(Fahrzeug.LKW);
   } else {
     removeKategorie(Fahrzeug.LKW);
   }
@@ -185,7 +193,7 @@ function updateKategorieWithLkw() {
 
 function updateKategorieWithLz() {
   if (lz.value) {
-    addKategorie(Fahrzeug.LZ);
+    addKategorieToZaehlung(Fahrzeug.LZ);
   } else {
     removeKategorie(Fahrzeug.LZ);
   }
@@ -193,7 +201,7 @@ function updateKategorieWithLz() {
 
 function updateKategorieWithBus() {
   if (bus.value) {
-    addKategorie(Fahrzeug.BUS);
+    addKategorieToZaehlung(Fahrzeug.BUS);
   } else {
     removeKategorie(Fahrzeug.BUS);
   }
@@ -201,7 +209,7 @@ function updateKategorieWithBus() {
 
 function updateKategorieWithKrad() {
   if (krad.value) {
-    addKategorie(Fahrzeug.KRAD);
+    addKategorieToZaehlung(Fahrzeug.KRAD);
   } else {
     removeKategorie(Fahrzeug.KRAD);
   }
@@ -209,7 +217,7 @@ function updateKategorieWithKrad() {
 
 function updateKategorieWithRad() {
   if (rad.value) {
-    addKategorie(Fahrzeug.RAD);
+    addKategorieToZaehlung(Fahrzeug.RAD);
   } else {
     removeKategorie(Fahrzeug.RAD);
   }
@@ -217,7 +225,7 @@ function updateKategorieWithRad() {
 
 function updateKategorieWithFuss() {
   if (fuss.value) {
-    addKategorie(Fahrzeug.FUSS);
+    addKategorieToZaehlung(Fahrzeug.FUSS);
   } else {
     removeKategorie(Fahrzeug.FUSS);
   }
@@ -229,29 +237,39 @@ function updateKategorieWithFuss() {
  * @private
  */
 function selectOrDeselectAll() {
-  pkw.value = selectOrDeselectAllVmodel.value;
-  lkw.value = selectOrDeselectAllVmodel.value;
-  lz.value = selectOrDeselectAllVmodel.value;
-  bus.value = selectOrDeselectAllVmodel.value;
-  krad.value = selectOrDeselectAllVmodel.value;
+  // Setzen der Checkboxen
+  if (allCategoriesAreAllowed.value) {
+    pkw.value = selectOrDeselectAllVmodel.value;
+    lkw.value = selectOrDeselectAllVmodel.value;
+    lz.value = selectOrDeselectAllVmodel.value;
+    bus.value = selectOrDeselectAllVmodel.value;
+    krad.value = selectOrDeselectAllVmodel.value;
+  } else {
+    pkw.value = false;
+    lkw.value = false;
+    lz.value = false;
+    bus.value = false;
+    krad.value = false;
+  }
   rad.value = selectOrDeselectAllVmodel.value;
   fuss.value = selectOrDeselectAllVmodel.value;
+
+  // Hinzufügen der Kategorien zur Zählung.
   zaehlung.value.kategorien = [];
   if (selectOrDeselectAllVmodel.value) {
     if (allCategoriesAreAllowed.value) {
-      addKategorie(Fahrzeug.PKW);
-      addKategorie(Fahrzeug.PKW);
-      addKategorie(Fahrzeug.LKW);
-      addKategorie(Fahrzeug.LZ);
-      addKategorie(Fahrzeug.BUS);
-      addKategorie(Fahrzeug.KRAD);
+      addKategorieToZaehlung(Fahrzeug.PKW);
+      addKategorieToZaehlung(Fahrzeug.LKW);
+      addKategorieToZaehlung(Fahrzeug.LZ);
+      addKategorieToZaehlung(Fahrzeug.BUS);
+      addKategorieToZaehlung(Fahrzeug.KRAD);
     }
-    addKategorie(Fahrzeug.RAD);
-    addKategorie(Fahrzeug.FUSS);
+    addKategorieToZaehlung(Fahrzeug.RAD);
+    addKategorieToZaehlung(Fahrzeug.FUSS);
   }
 }
 
-function addKategorie(kategorie: Fahrzeug) {
+function addKategorieToZaehlung(kategorie: Fahrzeug) {
   zaehlung.value.kategorien.push(kategorie);
 }
 
@@ -275,7 +293,13 @@ function resetForm() {
   krad.value = zaehlung.value.kategorien.includes(Fahrzeug.KRAD);
   rad.value = zaehlung.value.kategorien.includes(Fahrzeug.RAD);
   fuss.value = zaehlung.value.kategorien.includes(Fahrzeug.FUSS);
-  selectOrDeselectAllVmodel.value = zaehlung.value.kategorien.length === 7;
+  let numberOfChoosableCategories;
+  if (checkIfZaehlartOfZaehlungAllowsAllCategories()) {
+    numberOfChoosableCategories = 7;
+  } else {
+    numberOfChoosableCategories = 2;
+  }
+  selectOrDeselectAllVmodel.value =
+    zaehlung.value.kategorien.length === numberOfChoosableCategories;
 }
 </script>
-

--- a/frontend/tests/components/zaehlung/VerkehrsartForm.spec.ts
+++ b/frontend/tests/components/zaehlung/VerkehrsartForm.spec.ts
@@ -1,0 +1,219 @@
+import { shallowMount } from "@vue/test-utils";
+import { createPinia } from "pinia";
+import { beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { createVuetify } from "vuetify";
+import * as components from "vuetify/components";
+import * as directives from "vuetify/directives";
+
+import VerkehrsartForm from "@/components/zaehlung/form/VerkehrsartForm.vue";
+import { usePkweinheitStore } from "@/store/PkweinheitStore";
+import Fahrzeug from "@/types/enum/Fahrzeug";
+import Zaehlart from "@/types/enum/Zaehlart";
+
+const pinia = createPinia();
+
+describe("VerkehrsartForm.vue - Funktionen", () => {
+  let vuetify: ReturnType<typeof createVuetify>;
+
+  beforeAll(() => {
+    createPinia();
+    createVuetify();
+  });
+
+  beforeEach(() => {
+    vuetify = createVuetify({ components, directives });
+  });
+
+  function createWrapper(zaehlungProp: any) {
+    // Sicherstellen, dass der Store existiert und sinnvolle Standardwerte hat
+    const wrapper = shallowMount(VerkehrsartForm, {
+      global: {
+        plugins: [pinia, vuetify],
+      },
+      props: {
+        // Die Komponente erwartet ein Model (defineModel) - das wird als modelValue prop übergeben
+        modelValue: zaehlungProp,
+        height: "Dummy",
+      },
+    });
+
+    // Setze eine sinnvolle PkwEinheit im Store, damit die berechneten Labels nicht auf undefined zugreifen
+    const pkStore = usePkweinheitStore();
+    pkStore.setPkwEinheit({
+      pkw: 1,
+      lkw: 2,
+      lastzuege: 3,
+      busse: 4,
+      kraftraeder: 0.5,
+      fahrradfahrer: 0.2,
+      fussgaenger: 0.1,
+    } as any);
+
+    return wrapper;
+  }
+
+  it("checkIfZaehlartOfZaehlungAllowsAllCategories gibt false zurück für restriktive Zählarten", () => {
+    const restricted = [Zaehlart.QJS, Zaehlart.QU, Zaehlart.FJS];
+    restricted.forEach((z) => {
+      const wrapper = createWrapper({ zaehlart: z, kategorien: [] });
+      // Funktion ist auf vm verfügbar
+      const result = (
+        wrapper.vm as any
+      ).checkIfZaehlartOfZaehlungAllowsAllCategories();
+      expect(result).toBe(false);
+    });
+  });
+
+  it("checkIfZaehlartOfZaehlungAllowsAllCategories gibt true zurück für nicht-restriktive Zählart", () => {
+    const wrapper = createWrapper({ zaehlart: Zaehlart.N, kategorien: [] });
+    const result = (
+      wrapper.vm as any
+    ).checkIfZaehlartOfZaehlungAllowsAllCategories();
+    expect(result).toBe(true);
+  });
+
+  it("updateKategorieWith... fügt Kategorien hinzu und entfernt sie basierend auf dem Checkbox-Ref-Status", () => {
+    const wrapper = createWrapper({ zaehlart: Zaehlart.N, kategorien: [] });
+    const vm: any = wrapper.vm;
+
+    // Pkw hinzufügen
+    vm.pkw = true;
+    vm.updateKategorieWithPkw();
+    expect(vm.zaehlung.kategorien).toContain(Fahrzeug.PKW);
+
+    // Pkw entfernen
+    vm.pkw = false;
+    vm.updateKategorieWithPkw();
+    expect(vm.zaehlung.kategorien).not.toContain(Fahrzeug.PKW);
+
+    // Rad hinzufügen
+    vm.rad = true;
+    vm.updateKategorieWithRad();
+    expect(vm.zaehlung.kategorien).toContain(Fahrzeug.RAD);
+
+    // Rad entfernen
+    vm.rad = false;
+    vm.updateKategorieWithRad();
+    expect(vm.zaehlung.kategorien).not.toContain(Fahrzeug.RAD);
+  });
+
+  it("selectOrDeselectAll wählt alle verfügbaren Kategorien aus, wenn aktiviert und die Zählart alle erlaubt", () => {
+    const wrapper = createWrapper({ zaehlart: Zaehlart.N, kategorien: [] });
+    const vm: any = wrapper.vm;
+
+    vm.selectOrDeselectAllVmodel = true; // simuliert das Aktivieren der 'Alles auswählen'-Checkbox
+    // Ensure zaehlart allows all categories
+    vm.zaehlung.zaehlart = Zaehlart.N;
+
+    vm.selectOrDeselectAll();
+
+    // Wenn alle wählbar sind, sollten diese true sein
+    expect(vm.pkw).toBe(true);
+    expect(vm.lkw).toBe(true);
+    expect(vm.lz).toBe(true);
+    expect(vm.bus).toBe(true);
+    expect(vm.krad).toBe(true);
+    expect(vm.rad).toBe(true);
+    expect(vm.fuss).toBe(true);
+
+    // Und zaehlung.kategorien sollte alle diese Einträge enthalten
+    expect(vm.zaehlung.kategorien).toContain(Fahrzeug.PKW);
+    expect(vm.zaehlung.kategorien).toContain(Fahrzeug.LKW);
+    expect(vm.zaehlung.kategorien).toContain(Fahrzeug.LZ);
+    expect(vm.zaehlung.kategorien).toContain(Fahrzeug.BUS);
+    expect(vm.zaehlung.kategorien).toContain(Fahrzeug.KRAD);
+    expect(vm.zaehlung.kategorien).toContain(Fahrzeug.RAD);
+    expect(vm.zaehlung.kategorien).toContain(Fahrzeug.FUSS);
+  });
+
+  it("selectOrDeselectAll wählt nur Rad und Fuss aus, wenn die Zählart Kategorien einschränkt", () => {
+    const wrapper = createWrapper({ zaehlart: Zaehlart.QJS, kategorien: [] });
+    const vm: any = wrapper.vm;
+
+    vm.selectOrDeselectAllVmodel = true;
+    vm.zaehlung.zaehlart = Zaehlart.QJS;
+
+    vm.selectOrDeselectAll();
+
+    // Restriktive Kategorien sollten false sein
+    expect(vm.pkw).toBe(false);
+    expect(vm.lkw).toBe(false);
+    expect(vm.lz).toBe(false);
+    expect(vm.bus).toBe(false);
+    expect(vm.krad).toBe(false);
+
+    // Rad und Fuss folgen weiterhin dem Wert der 'Alles auswählen/abwählen'-Checkbox
+    expect(vm.rad).toBe(true);
+    expect(vm.fuss).toBe(true);
+
+    // Und zaehlung.kategorien sollte nur RAD und FUSS enthalten
+    expect(vm.zaehlung.kategorien).toEqual(
+      expect.arrayContaining([Fahrzeug.RAD, Fahrzeug.FUSS])
+    );
+    expect(vm.zaehlung.kategorien.length).toBe(2);
+  });
+
+  it("addKategorieToZaehlung fügt Duplikate hinzu, wenn mehrfach aufgerufen (erwartetes Verhalten) und removeKategorie entfernt nur eine Instanz", () => {
+    const wrapper = createWrapper({ zaehlart: Zaehlart.N, kategorien: [] });
+    const vm: any = wrapper.vm;
+
+    vm.addKategorieToZaehlung(Fahrzeug.PKW);
+    vm.addKategorieToZaehlung(Fahrzeug.PKW);
+    expect(
+      vm.zaehlung.kategorien.filter((k: any) => k === Fahrzeug.PKW).length
+    ).toBe(2);
+
+    // removeKategorie sollte nur das erste Vorkommen entfernen
+    vm.removeKategorie(Fahrzeug.PKW);
+    expect(
+      vm.zaehlung.kategorien.filter((k: any) => k === Fahrzeug.PKW).length
+    ).toBe(1);
+
+    // Das Entfernen einer nicht vorhandenen Kategorie sollte keinen Fehler werfen und das Array unverändert lassen
+    const before = [...vm.zaehlung.kategorien];
+    vm.removeKategorie(Fahrzeug.LKW);
+    expect(vm.zaehlung.kategorien).toEqual(before);
+  });
+
+  it("resetForm setzt Checkbox-Refs entsprechend zaehlung.kategorien und setzt selectOrDeselectAllVmodel basierend auf der Anzahl wählbarer Kategorien", () => {
+    // Unbeschränkte Zählart: numberOfChoosableCategories = 7
+    const wrapper1 = createWrapper({
+      zaehlart: Zaehlart.N,
+      kategorien: [
+        Fahrzeug.PKW,
+        Fahrzeug.LKW,
+        Fahrzeug.LZ,
+        Fahrzeug.BUS,
+        Fahrzeug.KRAD,
+        Fahrzeug.RAD,
+        Fahrzeug.FUSS,
+      ],
+    });
+    const vm1: any = wrapper1.vm;
+    vm1.resetForm();
+    expect(vm1.pkw).toBe(true);
+    expect(vm1.lkw).toBe(true);
+    expect(vm1.lz).toBe(true);
+    expect(vm1.bus).toBe(true);
+    expect(vm1.krad).toBe(true);
+    expect(vm1.rad).toBe(true);
+    expect(vm1.fuss).toBe(true);
+    expect(vm1.selectOrDeselectAllVmodel).toBe(true);
+
+    // Restriktive Zählart: numberOfChoosableCategories = 2
+    const wrapper2 = createWrapper({
+      zaehlart: Zaehlart.QJS,
+      kategorien: [Fahrzeug.RAD, Fahrzeug.FUSS],
+    });
+    const vm2: any = wrapper2.vm;
+    vm2.resetForm();
+    expect(vm2.pkw).toBe(false);
+    expect(vm2.lkw).toBe(false);
+    expect(vm2.lz).toBe(false);
+    expect(vm2.bus).toBe(false);
+    expect(vm2.krad).toBe(false);
+    expect(vm2.rad).toBe(true);
+    expect(vm2.fuss).toBe(true);
+    expect(vm2.selectOrDeselectAllVmodel).toBe(true);
+  });
+});


### PR DESCRIPTION
# Description

Fix Bug mit Aus- und Abwahl aller Fahrzeugkategorien bei Zählarten QJS, FJS und QU

# Issue References

FV-236 
 
# Definition of Done

<!-- Check all completed DoD requirements here -->

- [ ] Acceptance criteria are met
- [ ] Testing is done (unit-tests, DEV-environment)
- [ ] Build/Test workflow has successfully finished
- [ ] Release notes are complemented
- [ ] Documentation is complemented (operator manual, system specification, etc.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed vehicle-category checkbox visibility and selection so certain counting types restrict PKW/LKW/LZ/Bus/Krad options.
  * Improved "select all"/reset behavior: selecting/deselecting now respects allowed categories and reliably resets selections.

* **Tests**
  * Added unit tests covering category allowance logic, checkbox add/remove behavior, select-all variations, and form reset synchronization.

* **Style**
  * Minor label formatting refinements for empty-string cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->