### PR TITLE
Fv 279 kopieren von zaehlung nicht moeglich

### DIFF
--- a/frontend/src/components/zaehlung/ZaehlungCard.vue
+++ b/frontend/src/components/zaehlung/ZaehlungCard.vue
@@ -256,6 +256,7 @@
 import type BackendIdDTO from "@/types/common/BackendIdDTO";
 import type GeoPoint from "@/types/common/GeoPoint";
 import type DienstleisterDTO from "@/types/config/DienstleisterDTO";
+import type HochrechnungsfaktorDTO from "@/types/config/HochrechnungsfaktorDTO";
 import type KnotenarmDTO from "@/types/zaehlung/KnotenarmDTO";
 import type LaengsverkehrDTO from "@/types/zaehlung/LaengsverkehrDTO";
 import type QuerungsverkehrDTO from "@/types/zaehlung/QuerungsverkehrDTO";
@@ -290,6 +291,7 @@ interface Props {
   geoPointZaehlstelle: GeoPoint;
   zaehlstelleId: string;
 }
+
 const properties = defineProps<Props>();
 
 const zaehlung = defineModel<ZaehlungDTO>({
@@ -513,7 +515,17 @@ function zaehlungKopieren() {
         if (vz.hochrechnungsfaktor) {
           vz.hochrechnungsfaktor.id = "";
         } else {
-          vz.hochrechnungsfaktor = { id: "" } as any;
+          vz.hochrechnungsfaktor = {
+            id: "",
+            entityVersion: 0,
+            createdTime: "",
+            matrix: "NON",
+            kfz: 0,
+            sv: 0,
+            gv: 0,
+            active: true,
+            defaultFaktor: false,
+          } as HochrechnungsfaktorDTO;
         }
       });
     }

--- a/frontend/src/components/zaehlung/ZaehlungCard.vue
+++ b/frontend/src/components/zaehlung/ZaehlungCard.vue
@@ -503,16 +503,51 @@ function zaehlungKopieren() {
   zaehlungCopy.knotenarme.forEach((arm: KnotenarmDTO) => {
     arm.id = "";
   });
-  zaehlungCopy.verkehrsbeziehungen.forEach((vz: VerkehrsbeziehungDTO) => {
-    vz.id = "";
-    vz.hochrechnungsfaktor.id = "";
-  });
-  zaehlungCopy.querungsverkehr.forEach((qv: QuerungsverkehrDTO) => {
-    qv.id = "";
-  });
-  zaehlungCopy.laengsverkehr.forEach((lv: LaengsverkehrDTO) => {
-    lv.id = "";
-  });
+
+  try {
+    if (!zaehlungCopy.verkehrsbeziehungen) {
+      zaehlungCopy.verkehrsbeziehungen = [];
+    } else {
+      zaehlungCopy.verkehrsbeziehungen.forEach((vz: VerkehrsbeziehungDTO) => {
+        vz.id = "";
+        if (vz.hochrechnungsfaktor) {
+          vz.hochrechnungsfaktor.id = "";
+        } else {
+          vz.hochrechnungsfaktor = { id: "" } as any;
+        }
+      });
+    }
+  } catch (error) {
+    snackbarStore.showError("Fehler beim Kopieren der Verkehrsbeziehungen.");
+    console.error(error);
+  }
+
+  try {
+    if (!zaehlungCopy.querungsverkehr) {
+      zaehlungCopy.querungsverkehr = [];
+    } else {
+      zaehlungCopy.querungsverkehr.forEach((qv: QuerungsverkehrDTO) => {
+        qv.id = "";
+      });
+    }
+  } catch (error) {
+    snackbarStore.showError("Fehler beim Kopieren des Querungsverkehrs.");
+    console.error(error);
+  }
+
+  try {
+    if (!zaehlungCopy.laengsverkehr) {
+      zaehlungCopy.laengsverkehr = [];
+    } else {
+      zaehlungCopy.laengsverkehr.forEach((lv: LaengsverkehrDTO) => {
+        lv.id = "";
+      });
+    }
+  } catch (error) {
+    snackbarStore.showError("Fehler beim Kopieren des Längsverkehrs.");
+    console.error(error);
+  }
+
   ZaehlungService.saveZaehlung(zaehlungCopy, properties.zaehlstelleId)
     .then((backendIdDTO: BackendIdDTO) => {
       snackbarStore.showInfo(`Die Zählung vom ${datum.value} wurde kopiert.`);

--- a/frontend/src/components/zaehlung/ZaehlungCard.vue
+++ b/frontend/src/components/zaehlung/ZaehlungCard.vue
@@ -520,6 +520,8 @@ function zaehlungKopieren() {
   } catch (error) {
     snackbarStore.showError("Fehler beim Kopieren der Verkehrsbeziehungen.");
     console.error(error);
+    loading.value = false;
+    return;
   }
 
   try {
@@ -533,6 +535,8 @@ function zaehlungKopieren() {
   } catch (error) {
     snackbarStore.showError("Fehler beim Kopieren des Querungsverkehrs.");
     console.error(error);
+    loading.value = false;
+    return;
   }
 
   try {
@@ -546,6 +550,8 @@ function zaehlungKopieren() {
   } catch (error) {
     snackbarStore.showError("Fehler beim Kopieren des Längsverkehrs.");
     console.error(error);
+    loading.value = false;
+    return;
   }
 
   ZaehlungService.saveZaehlung(zaehlungCopy, properties.zaehlstelleId)

--- a/frontend/src/components/zaehlung/form/VerkehrsartForm.vue
+++ b/frontend/src/components/zaehlung/form/VerkehrsartForm.vue
@@ -140,31 +140,31 @@ const notOnlyRadAndFussIsAllowed = computed(() => {
 });
 
 const pkwLabel = computed(() => {
-  return `Personenkraftwagen (Pkw) ${pkwEinheitenOfStore.value.pkw ? `- PKW-Einheit-Faktor: ${pkwEinheitenOfStore.value.pkw}` : ''}`;
+  return `Personenkraftwagen (Pkw) ${pkwEinheitenOfStore.value.pkw ? `- PKW-Einheit-Faktor: ${pkwEinheitenOfStore.value.pkw}` : ""}`;
 });
 
 const lkwLabel = computed(() => {
-  return `Lastkraftwagen (Lkw) ${pkwEinheitenOfStore.value.lkw ? `- PKW-Einheit-Faktor: ${pkwEinheitenOfStore.value.lkw}` : ''}`;
+  return `Lastkraftwagen (Lkw) ${pkwEinheitenOfStore.value.lkw ? `- PKW-Einheit-Faktor: ${pkwEinheitenOfStore.value.lkw}` : ""}`;
 });
 
 const lzLabel = computed(() => {
-  return `Lastzüge (Lz) ${pkwEinheitenOfStore.value.lastzuege ? `- PKW-Einheit-Faktor: ${pkwEinheitenOfStore.value.lastzuege}` : ''}`;
+  return `Lastzüge (Lz) ${pkwEinheitenOfStore.value.lastzuege ? `- PKW-Einheit-Faktor: ${pkwEinheitenOfStore.value.lastzuege}` : ""}`;
 });
 
 const busLabel = computed(() => {
-  return `Bus ${pkwEinheitenOfStore.value.busse ? `- PKW-Einheit-Faktor: ${pkwEinheitenOfStore.value.busse}` : ''}`;
+  return `Bus ${pkwEinheitenOfStore.value.busse ? `- PKW-Einheit-Faktor: ${pkwEinheitenOfStore.value.busse}` : ""}`;
 });
 
 const kradLabel = computed(() => {
-  return `Krafträder (Krad) ${pkwEinheitenOfStore.value.kraftraeder ? `- PKW-Einheit-Faktor: ${pkwEinheitenOfStore.value.kraftraeder}` : ''}`;
+  return `Krafträder (Krad) ${pkwEinheitenOfStore.value.kraftraeder ? `- PKW-Einheit-Faktor: ${pkwEinheitenOfStore.value.kraftraeder}` : ""}`;
 });
 
 const radLabel = computed(() => {
-  return `Radverkehr ${pkwEinheitenOfStore.value.fahrradfahrer ? `- PKW-Einheit-Faktor: ${pkwEinheitenOfStore.value.fahrradfahrer}` : ''}`;
+  return `Radverkehr ${pkwEinheitenOfStore.value.fahrradfahrer ? `- PKW-Einheit-Faktor: ${pkwEinheitenOfStore.value.fahrradfahrer}` : ""}`;
 });
 
 const fussLabel = computed(() => {
-  return `Fußverkehr ${pkwEinheitenOfStore.value.fussgaenger ? `- PKW-Einheit-Faktor: ${pkwEinheitenOfStore.value.fussgaenger}` : ''}`;
+  return `Fußverkehr ${pkwEinheitenOfStore.value.fussgaenger ? `- PKW-Einheit-Faktor: ${pkwEinheitenOfStore.value.fussgaenger}` : ""}`;
 });
 
 function updateKategorieWithPkw() {
@@ -279,4 +279,3 @@ function resetForm() {
   selectOrDeselectAllVmodel.value = zaehlung.value.kategorien.length === 7;
 }
 </script>
-


### PR DESCRIPTION
# Description

FV-279 Kopieren von Zählung nicht möglich

# Definition of Done

<!-- Check all completed DoD requirements here -->

- [x] Acceptance criteria are met
- [x] Testing is done (unit-tests, DEV-environment)
- [x] Build/Test workflow has successfully finished
- [x] Release notes are complemented
- [x] Documentation is complemented (operator manual, system specification, etc.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Copying a traffic record now handles missing or incomplete traffic sections safely, avoiding crashes.
  * If a section of the copy fails, users see a clear, section-specific error and the operation stops to prevent partial saves.

* **Style**
  * Updated label formatting for several traffic types and performed minor script cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->