### PR TITLE
FV-323 Fix Bug: Alle Verkehrsarten auswaehlen und Speichern fehlerhaft

### DIFF
--- a/frontend/src/components/zaehlung/form/VerkehrsartForm.vue
+++ b/frontend/src/components/zaehlung/form/VerkehrsartForm.vue
@@ -8,6 +8,13 @@
     <v-card-text>
       <v-row dense>
         <v-col>
+          <v-btn
+            class="text-none"
+            density="compact"
+            variant="outlined"
+            :text="labelSelectOrDeselectAll"
+            @click="selectOrDeselectAll()"
+          />
           <v-checkbox
             v-if="areAllVehicleCategoriesSelectable"
             v-model="pkw"
@@ -61,13 +68,6 @@
             color="quaternary"
             hide-details
             @update:model-value="updateKategorieWithFuss"
-          />
-          <v-checkbox
-            v-model="selectOrDeselectAllVmodel"
-            :label="labelSelectOrDeselectAll"
-            color="quaternary"
-            hide-details
-            @update:model-value="selectOrDeselectAll()"
           />
         </v-col>
       </v-row>
@@ -237,6 +237,7 @@ function updateKategorieWithFuss() {
  * @private
  */
 function selectOrDeselectAll() {
+  selectOrDeselectAllVmodel.value = !selectOrDeselectAllVmodel.value;
   // Setzen der Checkboxen
   if (areAllVehicleCategoriesSelectable.value) {
     pkw.value = selectOrDeselectAllVmodel.value;

--- a/frontend/src/components/zaehlung/form/VerkehrsartForm.vue
+++ b/frontend/src/components/zaehlung/form/VerkehrsartForm.vue
@@ -293,13 +293,22 @@ function resetForm() {
   krad.value = zaehlung.value.kategorien.includes(Fahrzeug.KRAD);
   rad.value = zaehlung.value.kategorien.includes(Fahrzeug.RAD);
   fuss.value = zaehlung.value.kategorien.includes(Fahrzeug.FUSS);
-  let numberOfChoosableCategories;
-  if (checkIfZaehlartOfZaehlungAllowsAllCategories()) {
-    numberOfChoosableCategories = 7;
-  } else {
-    numberOfChoosableCategories = 2;
-  }
+  const allowedCategories = checkIfZaehlartOfZaehlungAllowsAllCategories()
+    ? [
+        Fahrzeug.PKW,
+        Fahrzeug.LKW,
+        Fahrzeug.LZ,
+        Fahrzeug.BUS,
+        Fahrzeug.KRAD,
+        Fahrzeug.RAD,
+        Fahrzeug.FUSS,
+      ]
+    : [Fahrzeug.RAD, Fahrzeug.FUSS];
+
+  const choosableCategories = zaehlung.value.kategorien.filter((k) =>
+    allowedCategories.includes(k)
+  );
   selectOrDeselectAllVmodel.value =
-    zaehlung.value.kategorien.length === numberOfChoosableCategories;
+    choosableCategories.length === allowedCategories.length;
 }
 </script>

--- a/frontend/tests/components/zaehlung/VerkehrsartForm.spec.ts
+++ b/frontend/tests/components/zaehlung/VerkehrsartForm.spec.ts
@@ -140,7 +140,6 @@ describe("VerkehrsartForm.vue - Funktionen", () => {
     expect(vm.bus).toBe(false);
     expect(vm.krad).toBe(false);
 
-    // Rad und Fuss folgen weiterhin dem Wert der 'Alles auswählen/abwählen'-Checkbox
     expect(vm.rad).toBe(true);
     expect(vm.fuss).toBe(true);
 
@@ -174,7 +173,7 @@ describe("VerkehrsartForm.vue - Funktionen", () => {
   });
 
   it("resetForm setzt Checkbox-Refs entsprechend zaehlung.kategorien und setzt selectOrDeselectAllVmodel basierend auf der Anzahl wählbarer Kategorien", () => {
-    // Unbeschränkte Zählart: numberOfChoosableCategories = 7
+    // Unbeschränkte Zählart: choosableCategories.length = 7
     const wrapper1 = createWrapper({
       zaehlart: Zaehlart.N,
       kategorien: [
@@ -198,7 +197,7 @@ describe("VerkehrsartForm.vue - Funktionen", () => {
     expect(vm1.fuss).toBe(true);
     expect(vm1.selectOrDeselectAllVmodel).toBe(true);
 
-    // Restriktive Zählart: numberOfChoosableCategories = 2
+    // Restriktive Zählart: choosableCategories.length = 2
     const wrapper2 = createWrapper({
       zaehlart: Zaehlart.QJS,
       kategorien: [Fahrzeug.RAD, Fahrzeug.FUSS],

--- a/frontend/tests/components/zaehlung/VerkehrsartForm.spec.ts
+++ b/frontend/tests/components/zaehlung/VerkehrsartForm.spec.ts
@@ -101,11 +101,10 @@ describe("VerkehrsartForm.vue - Funktionen", () => {
     const wrapper = createWrapper({ zaehlart: Zaehlart.N, kategorien: [] });
     const vm: any = wrapper.vm;
 
-    vm.selectOrDeselectAllVmodel = true; // simuliert das Aktivieren der 'Alles auswählen'-Checkbox
     // Ensure zaehlart allows all categories
     vm.zaehlung.zaehlart = Zaehlart.N;
 
-    vm.selectOrDeselectAll();
+    vm.selectOrDeselectAll(); // simuliert das Klicken des 'Alles auswählen'-Buttons
 
     // Wenn alle wählbar sind, sollten diese true sein
     expect(vm.pkw).toBe(true);
@@ -130,10 +129,9 @@ describe("VerkehrsartForm.vue - Funktionen", () => {
     const wrapper = createWrapper({ zaehlart: Zaehlart.QJS, kategorien: [] });
     const vm: any = wrapper.vm;
 
-    vm.selectOrDeselectAllVmodel = true;
     vm.zaehlung.zaehlart = Zaehlart.QJS;
 
-    vm.selectOrDeselectAll();
+    vm.selectOrDeselectAll(); // simuliert das Klicken des 'Alles auswählen'-Buttons
 
     // Restriktive Kategorien sollten false sein
     expect(vm.pkw).toBe(false);


### PR DESCRIPTION
# Description

<!-- Add a short description of what the request is all about here -->

Die "Alles Auswählen"-Checkbox der Verkehrsarten wurde durch einen Button ersetzt. Außerdem wurde der Fehler behoben, dass der Text des Buttons/der Checkbox bei "Alles Auswählen" bleibt, obwohl alle Verkehrsarten ausgewählt sind.

# Issue References

<!-- Add the corresponding issues here -->

FV-323
 
# Definition of Done

<!-- Check all completed DoD requirements here -->

- [x] Acceptance criteria are met
- [x] Testing is done (unit-tests, DEV-environment)
- [x] Build/Test workflow has successfully finished
- [x] Release notes are complemented
~- [ ] Documentation is complemented (operator manual, system specification, etc.)~

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced the select/deselect all interaction in the traffic classification form interface.
  * Improved form reset functionality to dynamically determine available categories based on the selected traffic type.

* **Tests**
  * Updated test coverage to verify the modified form behavior and category selection logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->