### PR TITLE
FV-438 Anzeige von Strassennamen bei QjS

### DIFF
--- a/frontend/src/components/zaehlung/form/QuerschnittJeStrassenseiteForm.vue
+++ b/frontend/src/components/zaehlung/form/QuerschnittJeStrassenseiteForm.vue
@@ -355,7 +355,6 @@
 </template>
 
 <script setup lang="ts">
-import type KnotenarmDTO from "@/types/zaehlung/KnotenarmDTO";
 import type VerkehrsbeziehungDTO from "@/types/zaehlung/VerkehrsbeziehungDTO";
 import type ZaehlungDTO from "@/types/zaehlung/ZaehlungDTO";
 
@@ -364,6 +363,7 @@ import { computed, onMounted, ref, watch } from "vue";
 
 import Himmelsrichtung from "@/types/enum/Himmelsrichtung";
 import KnotenarmComparator from "@/util/KnotenarmComparator";
+import { useStrassennameUtils } from "@/util/StrassennameUtils";
 
 interface Props {
   height: string;
@@ -374,6 +374,8 @@ defineProps<Props>();
 const zaehlung = defineModel<ZaehlungDTO>("zaehlung", {
   required: true,
 });
+
+const strassennameUtils = useStrassennameUtils();
 
 const activeColor = "#D50000";
 const passiveColor = "#9E9E9E";
@@ -705,45 +707,7 @@ function resetForm(): void {
 }
 
 function prepareStreetnames(): void {
-  firstStreetname.value = getStreetname(firstNode.value);
-  secondStreetname.value = getStreetname(secondNode.value);
-}
-
-function getStreetname(knotenarm: KnotenarmDTO | undefined): Array<string> {
-  let strasse = "";
-  if (knotenarm && knotenarm.strassenname) {
-    strasse = knotenarm.strassenname;
-  }
-  let pieces = [strasse];
-  const zeichen = strasse.length;
-  // Anzahl Zeichen
-  if (zeichen > 17) {
-    pieces = ["", ""];
-    if (strasse.endsWith("str.")) {
-      const index = strasse.indexOf("str.");
-      pieces[0] = strasse.substring(0, zeichen - 4);
-      pieces[1] = strasse.substring(index, 4);
-    }
-    // Platz
-    if (strasse.endsWith("pl.")) {
-      const index = strasse.indexOf("pl.");
-      pieces[0] = strasse.substring(0, zeichen - 3);
-      pieces[1] = strasse.substring(index, 3);
-    }
-    // Bindestrich
-    if (strasse.includes("-")) {
-      // pieces = strasse.split(trenner);
-      const index = strasse.indexOf("-");
-      pieces[0] = strasse.substring(0, index + 1);
-      pieces[1] = strasse.substring(index + 1);
-    }
-    // Leerzeichen
-    else if (strasse.includes(" ")) {
-      const index = strasse.indexOf(" ");
-      pieces[0] = strasse.substring(0, index + 1);
-      pieces[1] = strasse.substring(index + 1);
-    }
-  }
-  return pieces;
+  firstStreetname.value = strassennameUtils.getStreetLines(firstNode.value);
+  secondStreetname.value = strassennameUtils.getStreetLines(secondNode.value);
 }
 </script>

--- a/frontend/src/util/StrassennameUtils.ts
+++ b/frontend/src/util/StrassennameUtils.ts
@@ -1,0 +1,207 @@
+import type KnotenarmDTO from "@/types/zaehlung/KnotenarmDTO";
+
+export function useStrassennameUtils() {
+  /**
+   * Extrahiert und splittet den Straßennamen eines Knotenarms
+   * @param knotenarm optionaler Knotenarm DTO
+   * @param maxChars maximale Zeichenanzahl in der ersten Zeile (Default: 17)
+   * @returns Array<string> mit einem oder zwei Elementen (falls gesplittet)
+   */
+  function getStreetname(
+    knotenarm: KnotenarmDTO | undefined,
+    maxChars = 17
+  ): Array<string> {
+    const strasse = (knotenarm?.strassenname ?? "").trim();
+    if (!strasse) {
+      return [""];
+    }
+
+    // Kurzfall: passt komplett
+    if (strasse.length <= maxChars) {
+      return [strasse];
+    }
+
+    // 1) Fallback: An Leerstelle trennen falls vorhanden
+    const lastSpaceBefore = strasse.lastIndexOf(" ");
+    if (lastSpaceBefore > 0 && lastSpaceBefore < strasse.length - 1) {
+      return [
+        strasse.substring(0, lastSpaceBefore + 1),
+        strasse.substring(lastSpaceBefore + 1),
+      ];
+    }
+
+    const lower = strasse.toLowerCase();
+
+    // 2) Bekannte Suffixe (ähnlich wie bisher), wenn am Ende vorhanden
+    const suffixes = [
+      "str.",
+      "strasse",
+      "straße",
+      "str",
+      "pl.",
+      "platz",
+      "allee",
+      "ring",
+      "weg",
+      "bruecke",
+      "brücke",
+      "damm",
+    ];
+    for (const suf of suffixes) {
+      if (lower.endsWith(suf)) {
+        const idx = lower.lastIndexOf(suf);
+        if (idx > 0) {
+          const value = strasse.substring(0, idx).trim();
+          return [
+            value.endsWith("-") ? value : value + "-",
+            strasse.substring(idx),
+          ];
+        }
+      }
+    }
+
+    // 3) Split an existierendem Bindestrich (macht Sinn bei Komposita)
+    const hyphenPos = strasse.indexOf("-");
+    if (hyphenPos > 0 && hyphenPos < strasse.length - 1) {
+      return [
+        strasse.substring(0, hyphenPos + 1), // Bindestrich am Ende der ersten Zeile
+        strasse.substring(hyphenPos + 1),
+      ];
+    }
+
+    // 4) Intelligentes Wort-Batching über Intl.Segmenter (wenn verfügbar)
+    try {
+      // Segmenter liefert Wort-/Whitespace-Sequenzen, die wir aneinanderfügen können
+      // Ziel: so viele ganze Segmente in Zeile 1 packen wie möglich (<= maxChars)
+      // Rest in Zeile 2
+      // Für German locale; kann ggf. parametrisiert werden
+      // @ts-ignore - Intl.Segmenter Type ggf. nicht vorhanden in TS-Lib
+      if (typeof Intl !== "undefined" && (Intl as any).Segmenter) {
+        // 'word' granularity gibt uns sinnvolle Wort/Trennstellen
+        const seg = new (Intl as any).Segmenter("de", { granularity: "word" });
+        const segments = Array.from(seg.segment(strasse)).map(
+          (s: any) =>
+            // s.segment enthält das Textstück (inkl. ggf. spaces/punct)
+            s.segment
+        );
+
+        let first = "";
+        let i = 0;
+        while (
+          i < segments.length &&
+          (first + segments[i]).length <= maxChars
+        ) {
+          first += segments[i];
+          i++;
+        }
+
+        // Falls nicht einmal ein Segment passt (sehr langes Wort), fallback weiter unten
+        if (i > 0) {
+          const rest = segments.slice(i).join("").trim();
+          return [first.trim(), rest];
+        }
+      }
+    } catch (e) {
+      // Segmenter ggf. nicht verfügbar — einfach weitermachen zu Fallbacks
+    }
+
+    // 5) Letzte Rettung: mittig schneiden (mit optionaler Silbentrennung würde das verbessert)
+    const mid = Math.ceil(strasse.length / 2);
+    return [
+      strasse.substring(0, mid).trim() + "-",
+      strasse.substring(mid).trim(),
+    ];
+  }
+
+  /**
+   * Zerlegt die übergebenen Straßennamen-Zeilen in Token inklusive nachfolgender Trenner.
+   *
+   * @param streetnameTokens Array von Zeilen-Strings (typischerweise das Ergebnis von getStreetname),
+   *                         die zusammen verarbeitet werden sollen.
+   * @returns Array von Strings, wobei jedes Element ein Token eventuell inklusive des
+   *          unmittelbar darauf folgenden Trenners (Leerzeichen oder Bindestrich) ist.
+   */
+  function getAllToken(streetnameTokens: string[]) {
+    return streetnameTokens.flatMap((line) => {
+      const tokensWithSeparators = [];
+      let currentToken = "";
+
+      for (const char of line) {
+        if (char === " " || char === "-") {
+          if (currentToken) {
+            tokensWithSeparators.push(currentToken + char);
+            currentToken = "";
+          } else {
+            currentToken += char;
+          }
+        } else {
+          currentToken += char;
+        }
+      }
+
+      if (currentToken) {
+        tokensWithSeparators.push(currentToken);
+      }
+
+      return tokensWithSeparators;
+    });
+  }
+
+  /**
+   * Gleicht die Länge zweier Zeilen eines String-Arrays, so dass beide Zeilen
+   * in etwa gleich lang sind und ganze Token (Wörter ohne Trenner) verwendet werden.
+   *
+   * @param streetnameTokens Array mit einem oder zwei Teilen, wie von getStreetname geliefert.
+   *                         Falls nur ein Element vorhanden ist, wird dieses unverändert zurückgegeben.
+   * @returns Array mit genau zwei Strings: [ersteZeile, zweiteZeile]. Bei kurzeren Eingaben kann
+   *          die zweite Zeile leer sein.
+   */
+  function balanceLines(streetnameTokens: string[]) {
+    // Wenn getStreetname.maxChars nicht überschritten wird
+    if (streetnameTokens.length === 1) return streetnameTokens;
+
+    // Extrahiere alle Token (mit Trenner)
+    const allTokens = getAllToken(streetnameTokens);
+    // Ziel: beide Zeilen sollen so kurz wie möglich und gleich lang sein
+    let bestSplitIndex = 0;
+    let minMaxLength = Infinity;
+
+    // Durch alle möglichen Aufteilungen iterieren
+    for (let i = 0; i <= allTokens.length; i++) {
+      const firstLineTokens = allTokens.slice(0, i);
+      const secondLineTokens = allTokens.slice(i);
+
+      const firstLineLength = firstLineTokens.join("").length;
+      const secondLineLength = secondLineTokens.join("").length;
+      const maxLength = Math.max(firstLineLength, secondLineLength);
+
+      // Prüfe, ob diese Aufteilung besser ist
+      if (maxLength < minMaxLength) {
+        minMaxLength = maxLength;
+        bestSplitIndex = i;
+      }
+    }
+
+    // Erstelle die beiden Zeilen mit dem angegebenen Trenner
+    const firstLineResult = allTokens.slice(0, bestSplitIndex).join("");
+    const secondLineResult = allTokens.slice(bestSplitIndex).join("");
+    return [firstLineResult, secondLineResult];
+  }
+
+  /**
+   * Liefert die beiden Zeilen (first/second) direkt für einen Knotenarm.
+   * Intern ruft diese Funktion die Tokenisierung (getStreetname / Segmenter) und dann
+   * balanceLines auf.
+   */
+  function getStreetLines(
+    knotenarm: KnotenarmDTO | undefined,
+    maxChars?: number
+  ): Array<string> {
+    const pieces = getStreetname(knotenarm, maxChars);
+    return balanceLines(pieces);
+  }
+
+  return {
+    getStreetLines,
+  };
+}

--- a/frontend/src/util/StrassennameUtils.ts
+++ b/frontend/src/util/StrassennameUtils.ts
@@ -30,9 +30,18 @@ export function useStrassennameUtils() {
       ];
     }
 
+    // 2) Split an existierendem Bindestrich (macht Sinn bei Komposita)
+    const hyphenPos = strasse.indexOf("-");
+    if (hyphenPos > 0 && hyphenPos < strasse.length - 1) {
+      return [
+        strasse.substring(0, hyphenPos + 1), // Bindestrich am Ende der ersten Zeile
+        strasse.substring(hyphenPos + 1),
+      ];
+    }
+
     const lower = strasse.toLowerCase();
 
-    // 2) Bekannte Suffixe (ähnlich wie bisher), wenn am Ende vorhanden
+    // 3) Bekannte Suffixe (ähnlich wie bisher), wenn am Ende vorhanden
     const suffixes = [
       "str.",
       "strasse",
@@ -58,15 +67,6 @@ export function useStrassennameUtils() {
           ];
         }
       }
-    }
-
-    // 3) Split an existierendem Bindestrich (macht Sinn bei Komposita)
-    const hyphenPos = strasse.indexOf("-");
-    if (hyphenPos > 0 && hyphenPos < strasse.length - 1) {
-      return [
-        strasse.substring(0, hyphenPos + 1), // Bindestrich am Ende der ersten Zeile
-        strasse.substring(hyphenPos + 1),
-      ];
     }
 
     // 4) Intelligentes Wort-Batching über Intl.Segmenter (wenn verfügbar)

--- a/frontend/tests/util/StrassennameUtilsTest.spec.ts
+++ b/frontend/tests/util/StrassennameUtilsTest.spec.ts
@@ -1,0 +1,227 @@
+import { describe, expect, it } from "vitest";
+
+import { useStrassennameUtils } from "@/util/StrassennameUtils";
+import type KnotenarmDTO from "@/types/zaehlung/KnotenarmDTO";
+
+describe("StrassennamenUtils", () => {
+  // getStreetname ------------------------------------
+  it("getStreetname: kurze Straße bleibt ein Element", () => {
+    const { getStreetLines } = useStrassennameUtils();
+    const result = getStreetLines({ strassenname: "Hauptstr." } as any);
+    expect(result).toEqual(["Hauptstr."]);
+  });
+
+  it("getStreetname: lange Straße mit 'str.' wird gesplittet", () => {
+    const { getStreetLines } = useStrassennameUtils();
+    const long = "SehrlangeBeispielstr.";
+    const res = getStreetLines({ strassenname: long } as any);
+    expect(res.length).toBe(2);
+    expect(res[0]).toBe("SehrlangeBeispiel-");
+    expect(res[1]).toBe("str.");
+  });
+
+  it("getStreetLines: langer Straßename mit 'strasse' wird gesplittet", () => {
+    const { getStreetLines } = useStrassennameUtils();
+    const long = "Himmelschlüsselstrasse";
+    const res = getStreetLines({ strassenname: long } as any);
+    expect(res[0]).toBe("Himmelschlüssel-");
+    expect(res[1]).toBe("strasse");
+  });
+
+  it("getStreetLines: Straßename mit genau Länge 20", () => {
+    const { getStreetLines } = useStrassennameUtils();
+    const long = "Marienklausenbrücke";
+    const res = getStreetLines({ strassenname: long } as KnotenarmDTO, 20);
+    expect(res[0]).toBe("Marienklausenbrücke");
+  });
+
+  it("getStreetLines: Straßename mit genau Länge 17", () => {
+    const { getStreetLines } = useStrassennameUtils();
+    const long = "Marienklausenbrücke";
+    const res = getStreetLines({ strassenname: long } as KnotenarmDTO, 17);
+    expect(res[0]).toBe("Marienklausen-");
+    expect(res[1]).toBe("brücke");
+  });
+
+  it("getStreetLines: langer Straßename mit Abkürzung '...'", () => {
+    const { getStreetLines } = useStrassennameUtils();
+    const long = "Elisabeth-zu-Gutten...str.";
+    const res = getStreetLines({ strassenname: long } as any);
+    expect(res[0]).toBe("Elisabeth-zu-");
+    expect(res[1]).toBe("Gutten...-str.");
+  });
+
+  it("getStreetLines: Platz der Opfer des Nationalsozialismus", () => {
+    const { getStreetLines } = useStrassennameUtils();
+    const long = "Platz der Opfer des Nationalsozialismus";
+    const res = getStreetLines({ strassenname: long } as any);
+    expect(res[0]).toBe("Platz der Opfer des ");
+    expect(res[1]).toBe("Nationalsozialismus");
+  });
+
+  it("getStreetLines: Mathilde-Berghofer-Weichner-Strasse", () => {
+    const { getStreetLines } = useStrassennameUtils();
+    const long = "Mathilde-Berghofer-Weichner-Strasse";
+    const res = getStreetLines({ strassenname: long } as any);
+    expect(res[0]).toBe("Mathilde-Berghofer-");
+    expect(res[1]).toBe("Weichner-Strasse");
+  });
+
+  it("getStreetLines: Autobahn-Raststätte-Obermenzing", () => {
+    const { getStreetLines } = useStrassennameUtils();
+    const long = "Autobahn-Raststätte-Obermenzing";
+    const res = getStreetLines({ strassenname: long } as any);
+    expect(res[0]).toBe("Autobahn-Raststätte-");
+    expect(res[1]).toBe("Obermenzing");
+  });
+
+  it("getStreetLines: Margarete-Schütte-Lihotzky-Str.", () => {
+    const { getStreetLines } = useStrassennameUtils();
+    const long = "Margarete-Schütte-Lihotzky-Str.";
+    const res = getStreetLines({ strassenname: long } as any);
+    expect(res[0]).toBe("Margarete-Schütte-");
+    expect(res[1]).toBe("Lihotzky-Str.");
+  });
+
+  it("getStreetLines: Anneliese-Fleyenschmidt-Straße", () => {
+    const { getStreetLines } = useStrassennameUtils();
+    const long = "Anneliese-Fleyenschmidt-Straße";
+    const res = getStreetLines({ strassenname: long } as any);
+    expect(res[0]).toBe("Anneliese-");
+    expect(res[1]).toBe("Fleyenschmidt-Straße");
+  });
+
+  it("getStreetLines: Clementine-von-Braunmühl-Weg", () => {
+    const { getStreetLines } = useStrassennameUtils();
+    const long = "Clementine-von-Braunmühl-Weg";
+    const res = getStreetLines({ strassenname: long } as any);
+    expect(res[0]).toBe("Clementine-von-");
+    expect(res[1]).toBe("Braunmühl-Weg");
+  });
+
+  it("getStreetLines: Elisabeth-zu-Gutt...-Str.", () => {
+    const { getStreetLines } = useStrassennameUtils();
+    const long = "Elisabeth-zu-Gutt...-Str.";
+    const res = getStreetLines({ strassenname: long } as any);
+    expect(res[0]).toBe("Elisabeth-zu-");
+    expect(res[1]).toBe("Gutt...-Str.");
+  });
+
+  it("getStreetLines: Rainer-Werner-Fassbinder-Pl.", () => {
+    const { getStreetLines } = useStrassennameUtils();
+    const long = "Rainer-Werner-Fassbinder-Pl.";
+    const res = getStreetLines({ strassenname: long } as any);
+    expect(res[0]).toBe("Rainer-Werner-");
+    expect(res[1]).toBe("Fassbinder-Pl.");
+  });
+
+  it("getStreetLines: Rainer-Werner Fassbinder Pl.", () => {
+    const { getStreetLines } = useStrassennameUtils();
+    const long = "Rainer-Werner Fassbinder Pl.";
+    const res = getStreetLines({ strassenname: long } as any);
+    expect(res[0]).toBe("Rainer-Werner ");
+    expect(res[1]).toBe("Fassbinder Pl.");
+  });
+
+  it("getStreetLines: Rainer Werner-Fassbinder Pl.", () => {
+    const { getStreetLines } = useStrassennameUtils();
+    const long = "Rainer Werner-Fassbinder Pl.";
+    const res = getStreetLines({ strassenname: long } as any);
+    expect(res[0]).toBe("Rainer Werner-");
+    expect(res[1]).toBe("Fassbinder Pl.");
+  });
+
+  it("getStreetLines: Rainer Werner-Fassbinder-Pl.", () => {
+    const { getStreetLines } = useStrassennameUtils();
+    const long = "Rainer Werner-Fassbinder-Pl.";
+    const res = getStreetLines({ strassenname: long } as any);
+    expect(res[0]).toBe("Rainer Werner-");
+    expect(res[1]).toBe("Fassbinder-Pl.");
+  });
+
+  it("getStreetLines: Luise-Kiesselbach-Platz (Tunneleinfahrt)", () => {
+    const { getStreetLines } = useStrassennameUtils();
+    const long = "Luise-Kiesselbach-Platz (Tunneleinfahrt)";
+    const res = getStreetLines({ strassenname: long } as any);
+    expect(res[0]).toBe("Luise-Kiesselbach-");
+    expect(res[1]).toBe("Platz (Tunneleinfahrt)");
+  });
+
+  it("getStreetLines: langer Straßename mit 'Str.' wird gesplittet", () => {
+    const { getStreetLines } = useStrassennameUtils();
+    const long = "Adalbert-Stifter-Str.";
+    const res = getStreetLines({ strassenname: long } as any);
+    expect(res[0]).toBe("Adalbert-");
+    expect(res[1]).toBe("Stifter-Str.");
+  });
+
+  it("getStreetLines: Name mit Blank am Ende 18 Zeichen bleibt ein Element", () => {
+    const { getStreetLines } = useStrassennameUtils();
+    const res = getStreetLines({ strassenname: "Genau18ZeichMiBla " } as any);
+    expect(res.length).toEqual(1);
+    expect(res).toEqual(["Genau18ZeichMiBla"]);
+  });
+
+  it("getStreetLines: Name ohne Blank am Ende 17 Zeichen bleibt ein Element", () => {
+    const { getStreetLines } = useStrassennameUtils();
+    const res = getStreetLines({ strassenname: "Genau17ZeichenOhn" } as any);
+    expect(res.length).toEqual(1);
+    expect(res).toEqual(["Genau17ZeichenOhn"]);
+  });
+
+  it("getStreetLines: Name mit Leerzeichentrenner und Blank am Ende 18 Zeichen bleibt ein Element", () => {
+    const { getStreetLines } = useStrassennameUtils();
+    const res = getStreetLines({ strassenname: "Genau18Zeic MiBla " } as any);
+    expect(res.length).toEqual(1);
+    expect(res).toEqual(["Genau18Zeic MiBla"]);
+  });
+
+  it("getStreetLines: Name mit Leerzeichentrenner und Blank am Ende 20 Zeichen wird getrennt", () => {
+    const { getStreetLines } = useStrassennameUtils();
+    const res = getStreetLines({ strassenname: "Genau20Zeic MiBla F" } as any);
+    expect(res.length).toEqual(2);
+    expect(res[0]).toBe("Genau20Zeic ");
+    expect(res[1]).toBe("MiBla F");
+  });
+
+  it("getStreetLines: kurzer Name mit Leerzeichen (<= 17 Zeichen) bleibt ein Element", () => {
+    const { getStreetLines } = useStrassennameUtils();
+    const res = getStreetLines({ strassenname: "Kleine Allee" } as any);
+    expect(res).toEqual(["Kleine Allee"]);
+  });
+
+  it("getStreetLines: langer Name mit Leerzeichen (> 17 Zeichen) wird am ersten Leerzeichen gesplittet", () => {
+    const { getStreetLines } = useStrassennameUtils();
+    const longWithSpace = "VeryLongStreetname ExampleStreet";
+    const res = getStreetLines({ strassenname: longWithSpace } as any);
+    expect(res.length).toBe(2);
+    expect(res[0]).toBe("VeryLongStreetname ");
+    expect(res[1]).toBe("ExampleStreet");
+  });
+
+  it("getStreetLines: langer Name mit Bindestrich wird am Bindestrich gesplittet (Bindestrich bleibt im ersten Teil)", () => {
+    const { getStreetLines } = useStrassennameUtils();
+    const langeMitBindestrich = "EinSehrLanger-TeilRest";
+    expect(langeMitBindestrich.length).toBeGreaterThan(20);
+
+    const res = getStreetLines({ strassenname: langeMitBindestrich } as any);
+
+    expect(res.length).toBe(2);
+    // Der erste Teil soll den Bindestrich am Ende enthalten
+    expect(res[0].endsWith("-")).toBe(true);
+    // Der zweite Teil ist alles hinter dem Bindestrich
+    expect(res[1]).toBe("TeilRest");
+  });
+
+  it("getStreetLines: undefined knotenarm liefert ein Array mit einem leeren String", () => {
+    const { getStreetLines } = useStrassennameUtils();
+    const res = getStreetLines(undefined);
+    expect(res).toEqual([""]);
+  });
+
+  it("getStreetLines: leerer strassenname liefert ein Array mit einem leeren String", () => {
+    const { getStreetLines } = useStrassennameUtils();
+    const res = getStreetLines({ strassenname: "" } as any);
+    expect(res).toEqual([""]);
+  });
+});

--- a/frontend/tests/util/StrassennameUtilsTest.spec.ts
+++ b/frontend/tests/util/StrassennameUtilsTest.spec.ts
@@ -1,7 +1,8 @@
+import type KnotenarmDTO from "@/types/zaehlung/KnotenarmDTO";
+
 import { describe, expect, it } from "vitest";
 
 import { useStrassennameUtils } from "@/util/StrassennameUtils";
-import type KnotenarmDTO from "@/types/zaehlung/KnotenarmDTO";
 
 describe("StrassennamenUtils", () => {
   // getStreetname ------------------------------------
@@ -48,7 +49,7 @@ describe("StrassennamenUtils", () => {
     const long = "Elisabeth-zu-Gutten...str.";
     const res = getStreetLines({ strassenname: long } as any);
     expect(res[0]).toBe("Elisabeth-zu-");
-    expect(res[1]).toBe("Gutten...-str.");
+    expect(res[1]).toBe("Gutten...str.");
   });
 
   it("getStreetLines: Platz der Opfer des Nationalsozialismus", () => {
@@ -223,5 +224,12 @@ describe("StrassennamenUtils", () => {
     const { getStreetLines } = useStrassennameUtils();
     const res = getStreetLines({ strassenname: "" } as any);
     expect(res).toEqual([""]);
+  });
+
+  it("getStreetLines: Manuell forcierter Zeilenumbruch (Himmel-schlüsselstr.)", () => {
+    const { getStreetLines } = useStrassennameUtils();
+    const res = getStreetLines({ strassenname: "Himmel-schlüsselstr." } as any);
+    expect(res[0]).toBe("Himmel-");
+    expect(res[1]).toBe("schlüsselstr.");
   });
 });


### PR DESCRIPTION
# Description

Adds `StrassennameUtils.ts` from dave-frontend to display streetnames correctly.

# Issue References

FV-438
 
# Definition of Done

<!-- Check all completed DoD requirements here -->

- [x] Acceptance criteria are met
- [x] Testing is done (unit-tests, DEV-environment)
- [x] Build/Test workflow has successfully finished
- [x] Release notes are complemented
- [x] Documentation is complemented (operator manual, system specification, etc.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved street-name line wrapping in the counting form, making long names display more cleanly and consistently.
  * Better handling for empty, hyphenated, and multi-word street names to reduce awkward line breaks.

* **Tests**
  * Added coverage for street-name formatting across common edge cases and split patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->