### PR TITLE
FV-428 Bugfix: Fehlerhaftes Kopieren einer Zählung

### DIFF
--- a/frontend/src/components/zaehlung/form/KnotenLageForm.vue
+++ b/frontend/src/components/zaehlung/form/KnotenLageForm.vue
@@ -229,6 +229,13 @@ watch(
   }
 );
 
+watch(
+  () => zaehlung.value.kreisverkehr,
+  () => {
+    zaehlung.value.fahrbeziehungen = [];
+  }
+);
+
 function resetForm() {
   // Alle Straßennamen löschen
   strassen.value = ["", "", "", "", "", "", "", ""];
@@ -278,10 +285,13 @@ function deleteKnotenarm(nummer: number) {
 
 function deleteAllFahrbeziehungByKnotenarmnummer(nummer: number) {
   const filtered = zaehlung.value.fahrbeziehungen.filter((fahrbeziehung) => {
-    if (fahrbeziehung.knotenarm === nummer) {
+    const shouldRemove = zaehlung.value.kreisverkehr
+      ? fahrbeziehung.knotenarm === nummer
+      : fahrbeziehung.von === nummer || fahrbeziehung.nach === nummer;
+    if (shouldRemove) {
       fahrbeziehung.active = false;
     }
-    return fahrbeziehung.knotenarm !== nummer;
+    return !shouldRemove;
   });
 
   zaehlung.value.fahrbeziehungen = [];


### PR DESCRIPTION
# Description

Fixes a bug, where verkehrsbeziehungen/fahrbeziehungen were not correctly updated, when a zaehlung was copied and modified.

# Issue References

FV-428
 
# Definition of Done

<!-- Check all completed DoD requirements here -->

- [x] Acceptance criteria are met
- [x] Testing is done (unit-tests, DEV-environment)
- [x] Build/Test workflow has successfully finished
- [x] Release notes are complemented
- [x] Documentation is complemented (operator manual, system specification, etc.)