### PR TITLE
FV-493 Abbrechen Button in Messstelle routet auf Hauptkarte zurück

### DIFF
--- a/frontend/src/components/messstelle/UpdateMessstelleForm.vue
+++ b/frontend/src/components/messstelle/UpdateMessstelleForm.vue
@@ -100,6 +100,7 @@ import type MessstelleEditDTO from "@/types/messstelle/MessstelleEditDTO";
 
 import { isEmpty, isNil } from "lodash";
 import { computed, ref } from "vue";
+import { useRouter } from "vue-router";
 
 import MessstelleService from "@/api/service/MessstelleService";
 import MessfaehigkeitForm from "@/components/messstelle/MessfaehigkeitForm.vue";
@@ -124,6 +125,7 @@ const messstelle = defineModel<MessstelleEditDTO>({
 
 const snackbarStore = useSnackbarStore();
 const daveUtils = useDaveUtils();
+const router = useRouter();
 
 const emits = defineEmits<{
   (e: "reload"): void;
@@ -158,14 +160,19 @@ function save(): void {
       })
       .catch((error) => snackbarStore.showApiError(error))
       .finally(() => {
-        cancel();
+        reloadMessstelle();
       });
   }
 }
 
-function cancel(): void {
+function reloadMessstelle(): void {
   activeTab.value = 0;
   emits("reload");
+}
+
+function cancel(): void {
+  activeTab.value = 0;
+  router.push("/");
 }
 
 function areAllFormsValid(): boolean {


### PR DESCRIPTION
# Description

Abbrechen Button in Messstelle geht auf Hauptkarte zurück.

# Issue References

FV-493
 
# Definition of Done

<!-- Check all completed DoD requirements here -->

- [x] Acceptance criteria are met
- [x] Testing is done (unit-tests, DEV-environment)
- [x] Build/Test workflow has successfully finished
- [x] Release notes are complemented
- [x] Documentation is complemented (operator manual, system specification, etc.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Canceling an edit now returns to the home page while resetting the form view.
  - The messstelle view now refreshes consistently after save attempts, including when an error occurs.
  - The active tab is reset and the latest data is reloaded after completing an update.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->